### PR TITLE
Make button labels compatible with GNOME HIG

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -16,20 +16,20 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 
 #: window.ui:106
-msgid "add note"
-msgstr "přidat poznámku"
+msgid "Add Note"
+msgstr "Přidat Poznámku"
 
 #: window.ui:115
-msgid "delete note"
-msgstr "odstranit poznámku"
+msgid "Delete Note"
+msgstr "Odstranit Poznámku"
 
 #: window.ui:127
-msgid "save note"
-msgstr "uložit poznámku"
+msgid "Save Note"
+msgstr "Uložit Poznámku"
 
 #: window.ui:139
-msgid "save note as"
-msgstr "uložit poznámku jako"
+msgid "Save Note as…"
+msgstr "Uložit Poznámku jako…"
 
 #: window.vala:86 window.vala:110 window.vala:141
 msgid "Choose a note"

--- a/po/it.po
+++ b/po/it.po
@@ -41,17 +41,17 @@ msgid "column"
 msgstr "colonna"
 
 #: src/window.ui:106
-msgid "add note"
-msgstr "aggiungi nota"
+msgid "Add Note"
+msgstr "Aggiungi Nota"
 
 #: src/window.ui:115
-msgid "delete note"
-msgstr "cancella nota"
+msgid "Delete Note"
+msgstr "Cancella Nota"
 
 #: src/window.ui:127
-msgid "save note"
-msgstr "salva nota"
+msgid "Save Note"
+msgstr "Salva Nota"
 
 #: src/window.ui:139
-msgid "save note as"
-msgstr "salva nota come"
+msgid "Save Note as…"
+msgstr "Salva Nota come…"

--- a/po/nl.po
+++ b/po/nl.po
@@ -41,17 +41,17 @@ msgid "column"
 msgstr "Kolom"
 
 #: src/window.ui:106
-msgid "add note"
-msgstr "Aantekening toevoegen"
+msgid "Add Note"
+msgstr "Aantekening Toevoegen"
 
 #: src/window.ui:115
-msgid "delete note"
-msgstr "Aantekening verwijderen"
+msgid "Delete Note"
+msgstr "Aantekening Verwijderen"
 
 #: src/window.ui:127
-msgid "save note"
-msgstr "Aantekening opslaan"
+msgid "Save Note"
+msgstr "Aantekening Opslaan"
 
 #: src/window.ui:139
-msgid "save note as"
-msgstr "Aantekening opslaan als"
+msgid "Save Note as…"
+msgstr "Aantekening Opslaan als…"

--- a/src/window.vala
+++ b/src/window.vala
@@ -85,19 +85,19 @@ namespace Notepad {
         add_button = new Gtk.Button ();
             add_button.set_icon_name ("list-add-symbolic");
             add_button.vexpand = false;
-            add_button.tooltip_text = _("add note");
+            add_button.tooltip_text = _("Add Note");
         delete_button = new Gtk.Button ();
             delete_button.set_icon_name ("list-remove-symbolic");
             delete_button.vexpand = false;
-            delete_button.tooltip_text = _("delete note");
+            delete_button.tooltip_text = _("Delete Note");
         save_button = new Gtk.Button ();
             save_button.set_icon_name ("document-save-symbolic");
             save_button.vexpand = false;
-            save_button.tooltip_text = _("save note");
+            save_button.tooltip_text = _("Save Note");
         save_as_button = new Gtk.Button ();
             save_as_button.set_icon_name ("document-save-as-symbolic");
             save_as_button.vexpand = false;
-            save_as_button.tooltip_text = _("save note as");
+            save_as_button.tooltip_text = _("Save Note as…");
 
         var headerbar = new Adw.HeaderBar();
         headerbar.pack_start(add_button);


### PR DESCRIPTION
According to GNOME HIG we should use Header Capitalization for these labels.

More info: https://developer.gnome.org/hig/guidelines/writing-style.html